### PR TITLE
Tjy dev

### DIFF
--- a/planet/control/CFreshManFirstOrder.py
+++ b/planet/control/CFreshManFirstOrder.py
@@ -226,8 +226,11 @@ class CFreshManFirstOrder(COrder, CUser):
                 except ValueError:
                     current_app.logger.info('secret_usid decode error : {}'.format(secret_usid))
                     from_user_order = None
+                if from_user_order == None:
+                    raise StatusError('分享者未购买商品')
             else:
                 from_user_order = None
+
 
             # 创建订单
             omid = str(uuid.uuid1())

--- a/planet/control/CFreshManFirstOrder.py
+++ b/planet/control/CFreshManFirstOrder.py
@@ -226,8 +226,6 @@ class CFreshManFirstOrder(COrder, CUser):
                 except ValueError:
                     current_app.logger.info('secret_usid decode error : {}'.format(secret_usid))
                     from_user_order = None
-                if from_user_order == None:
-                    raise StatusError('分享者未购买商品')
             else:
                 from_user_order = None
 

--- a/planet/control/CPay.py
+++ b/planet/control/CPay.py
@@ -201,11 +201,20 @@ class CPay():
             first = 20
             second = 30
             third = 50
-
+        # 新人首单里没有参与记录
             fresh_man_join_flow = FreshManJoinFlow.query.filter(
                 FreshManJoinFlow.isdelete == False,
                 FreshManJoinFlow.OMid == order_main.OMid,
             ).first()
+        # 新人是否有订单记录
+            is_fresh_man = None
+            if fresh_man_join_flow:
+                is_not_fresh_man = OrderMain.query.filter(
+                    OrderMain.isdelete == False,
+                    OrderMain.OMid == fresh_man_join_flow.OMid
+                ).first()
+                if not is_not_fresh_man:
+                    is_fresh_man = 1
         # 判断邀请人是否有购买记录
             fresh_man_join_flow_upid = None
             if fresh_man_join_flow and fresh_man_join_flow.UPid :
@@ -216,7 +225,7 @@ class CPay():
                     OrderMain.OMstatus > OrderMainStatus.wait_pay.value,
                 ).first()
 
-            if fresh_man_join_flow and fresh_man_join_flow.UPid and fresh_man_join_flow_upid:
+            if fresh_man_join_flow and fresh_man_join_flow.UPid and fresh_man_join_flow_upid and is_fresh_man:
                 fresh_man_join_count = FreshManJoinFlow.query.filter(
                     FreshManJoinFlow.isdelete == False,
                     FreshManJoinFlow.UPid == fresh_man_join_flow.UPid,

--- a/planet/control/CPay.py
+++ b/planet/control/CPay.py
@@ -22,7 +22,7 @@ from planet.extensions.register_ext import alipay, wx_pay, db
 from planet.extensions.weixin.pay import WeixinPayError
 from planet.models import User, UserCommission, ProductBrand, ProductItems, Items, TrialCommodity, OrderLogistics, \
     Products, Supplizer
-from planet.models import OrderMain, OrderPart, OrderPay, FreshManJoinFlow, ProductSku
+from planet.models import OrderMain, OrderPart, OrderPay, FreshManJoinFlow,FreshManFirstProduct, ProductSku
 from planet.models.commision import Commision
 from planet.service.STrade import STrade
 from planet.service.SUser import SUser
@@ -206,8 +206,17 @@ class CPay():
                 FreshManJoinFlow.isdelete == False,
                 FreshManJoinFlow.OMid == order_main.OMid,
             ).first()
+        # 判断邀请人是否有购买记录
+            fresh_man_join_flow_upid = None
+            if fresh_man_join_flow and fresh_man_join_flow.UPid :
+                fresh_man_join_flow_upid = OrderMain.query.filter(
+                    OrderMain.isdelete == True,
+                    OrderMain.USid == fresh_man_join_flow.UPid,
+                    OrderMain.OMfrom == OrderFrom.fresh_man.value,
+                    OrderMain.OMstatus > OrderMainStatus.wait_pay.value,
+                ).first()
 
-            if fresh_man_join_flow and fresh_man_join_flow.UPid:
+            if fresh_man_join_flow and fresh_man_join_flow.UPid and fresh_man_join_flow_upid:
                 fresh_man_join_count = FreshManJoinFlow.query.filter(
                     FreshManJoinFlow.isdelete == False,
                     FreshManJoinFlow.UPid == fresh_man_join_flow.UPid,

--- a/planet/control/CPay.py
+++ b/planet/control/CPay.py
@@ -201,12 +201,13 @@ class CPay():
             first = 20
             second = 30
             third = 50
-        # 新人首单里没有参与记录
+
             fresh_man_join_flow = FreshManJoinFlow.query.filter(
                 FreshManJoinFlow.isdelete == False,
                 FreshManJoinFlow.OMid == order_main.OMid,
             ).first()
-        # 新人是否有订单记录
+
+        # 新人是否没有订单记录
             is_fresh_man = None
             if fresh_man_join_flow:
                 is_not_fresh_man = OrderMain.query.filter(
@@ -215,11 +216,12 @@ class CPay():
                 ).first()
                 if not is_not_fresh_man:
                     is_fresh_man = 1
-        # 判断邀请人是否有购买记录
+
+        # 邀请人是否有购买记录
             fresh_man_join_flow_upid = None
-            if fresh_man_join_flow and fresh_man_join_flow.UPid :
+            if fresh_man_join_flow and fresh_man_join_flow.UPid and is_fresh_man:
                 fresh_man_join_flow_upid = OrderMain.query.filter(
-                    OrderMain.isdelete == True,
+                    OrderMain.isdelete == False,
                     OrderMain.USid == fresh_man_join_flow.UPid,
                     OrderMain.OMfrom == OrderFrom.fresh_man.value,
                     OrderMain.OMstatus > OrderMainStatus.wait_pay.value,
@@ -237,7 +239,7 @@ class CPay():
                 current_app.logger.info("当前邀请人 邀请了总共 {} ".format(fresh_man_join_count))
                 # 邀请人的新人首单
                 up_order_main = OrderMain.query.filter(
-                    OrderMain.isdelete == True,
+                    OrderMain.isdelete == False,
                     OrderMain.USid == fresh_man_join_flow.UPid,
                     OrderMain.OMfrom == OrderFrom.fresh_man.value,
                     OrderMain.OMstatus > OrderMainStatus.wait_pay.value,

--- a/planet/control/CPay.py
+++ b/planet/control/CPay.py
@@ -226,18 +226,19 @@ class CPay():
                 # 邀请人的新人首单佣金列表
                 up_order_fresh_commissions = UserCommission.query.filter(
                     UserCommission.isdelete == False,
+                    # OrderMain.OMinRefund == False,
                     UserCommission.USid == up_order_main.USid,
                     UserCommission.UCstatus >= UserCommissionStatus.preview.value,
                     UserCommission.UCtype == UserCommissionType.fresh_man.value,
-                    ).all()
+                    ).limit(3)
                 # 邀请人的新人首单佣金
                 commissions = 0
                 for commission in up_order_fresh_commissions:
                     commission = commission.to_dict()
                     commissions += commission['UCcommission']
                 if up_order_main :
-                    up_fresh_order_price = min(order_main.OMtrueMount, up_order_main.OMtrueMount)
-                    # 邀请人新品佣金小于这次新人反现并且这次新人在前三个返现的人之内
+                    up_fresh_order_price = up_order_main.OMtrueMount
+                    # 邀请人新品佣金小于这次新人返现并且这次新人在前三个返现的人之内
                     if commissions < up_fresh_order_price and fresh_man_join_count <= 3:
                         reward = fresh_man_join_flow.OMprice
                         if fresh_man_join_count == 1:

--- a/planet/control/CRefund.py
+++ b/planet/control/CRefund.py
@@ -559,7 +559,7 @@ class CRefund(object):
             if result["code"] != "10000":
                 raise ApiError('退款错误')
         return result
-
+    # cancel_commission是否发生在删除user_commission，ordermain，freshmain之后
     def _cancle_commision(self, *args, **kwargs):
         order_main = kwargs.get('order_main')
         order_part = kwargs.get('order_part')
@@ -569,6 +569,7 @@ class CRefund(object):
                     UserCommission.OMid == order_main.OMid,
                     UserCommission.isdelete == False
                 ).first()
+                # user_commision.FromUSid?
                 current_app.logger.info('检测到有新人首单退货。订单id是 {}, 用户id是 {}'.format(
                     order_main.OMid, user_commision.USid))
                 fresh_man_join_count = FreshManJoinFlow.query.filter(
@@ -582,16 +583,13 @@ class CRefund(object):
 
                 current_app.logger.info('当前用户已分享的有效新人首单商品订单有 {}'.format(fresh_man_join_count))
                 fresh_man_join_all = FreshManJoinFlow.query.filter(
-                FreshManJoinFlow.isdelete == False,
-                FreshManJoinFlow.UPid == fresh_man_join_flow.UPid,
-                FreshManJoinFlow.OMid == OrderMain.OMid,
-                OrderMain.OMstatus >= OrderMainStatus.wait_send.value,
-                OrderMain.OMinRefund == False,
-                OrderMain.isdelete == False
-                )   .all()
-                if fresh_man_join_count > 3:
-                    current_app.logger.info('分享次数超过3次。不减少佣金')
-                    return
+                    FreshManJoinFlow.isdelete == False,
+                    FreshManJoinFlow.UPid == user_commision.USid,
+                    FreshManJoinFlow.OMid == OrderMain.OMid,
+                    OrderMain.OMstatus >= OrderMainStatus.wait_send.value,
+                    OrderMain.OMinRefund == False,
+                    OrderMain.isdelete == False
+                ) .limit(3)
 
                 user_commision_max = UserCommission.query.filter(
                     UserCommission.USid == user_commision.USid,
@@ -601,6 +599,44 @@ class CRefund(object):
                 if not user_commision_max:
                     current_app.logger.info('该订单没有上级返佣')
                     return
+
+                # 邀请人新品佣金修改
+                user_order_main = OrderMain.query.filter(
+                    OrderMain.isdelete == False,
+                    OrderMain.USid == user_commision.USid,
+                    OrderMain.OMfrom == OrderFrom.fresh_man.value,
+                    OrderMain.OMstatus > OrderMainStatus.wait_pay.value,
+                    ).first()
+                user_fresh_order_price = user_order_main.OMtrueMount
+                first = 20
+                second = 30
+                third = 50
+                commissions = 0
+                fresh_man_count = 1
+                for fresh_man in fresh_man_join_all:
+                    fresh_man = fresh_man.to_dict()
+                    if commissions < user_fresh_order_price:
+                        reward = fresh_man['OMprice']
+                        if fresh_man_count == 1:
+                            reward = reward * (first / 100)
+                        elif fresh_man_count == 2:
+                            reward = reward * (second / 100)
+                        elif fresh_man_count == 3:
+                            reward = reward * (third / 100)
+                        else:
+                            break
+                        if reward + commissions > user_fresh_order_price:
+                            reward = user_fresh_order_price - commissions
+                        if reward:
+                            UserCommission.query.filter(
+                                UserCommission.isdelete == False,
+                                UserCommission.USid == fresh_man['UPid'],
+                                UserCommission.OMid == fresh_man['OMid'],
+                                ).update({
+                                'UCcommission': reward
+                            })
+                    fresh_man_count += 1
+
                 current_app.logger.info('开始修改用户的 最后一个返佣奖励 具体内容： {}'.format(user_commision_max.__dict__))
                 user_commision_max.UCstatus = UserCommissionStatus.error.value
                 return

--- a/planet/control/CRefund.py
+++ b/planet/control/CRefund.py
@@ -581,6 +581,14 @@ class CRefund(object):
                 ).count()
 
                 current_app.logger.info('当前用户已分享的有效新人首单商品订单有 {}'.format(fresh_man_join_count))
+                fresh_man_join_all = FreshManJoinFlow.query.filter(
+                FreshManJoinFlow.isdelete == False,
+                FreshManJoinFlow.UPid == fresh_man_join_flow.UPid,
+                FreshManJoinFlow.OMid == OrderMain.OMid,
+                OrderMain.OMstatus >= OrderMainStatus.wait_send.value,
+                OrderMain.OMinRefund == False,
+                OrderMain.isdelete == False
+                )   .all()
                 if fresh_man_join_count > 3:
                     current_app.logger.info('分享次数超过3次。不减少佣金')
                     return


### PR DESCRIPTION
### 新人首单的佣金提成规则的变动
* 只有有效的前三单算入佣金提成，从第一单到第三单分别按照其被分享者的新人首单商品的前%20，%30，%50来算。
* 按分享者购买的新人首单的价格为最高价格，如果超过这个价格，则最高也只是这个价格，如果其有效分享的前三单不超过这个价格，也不会多加钱。
* 分享者如果退款，其新人首单应到金额和已到金额都应该被清零。
---
### 修改部分
* 对创建有邀请人的新人订单的佣金抽成进行了修改
* 对新人首单的退款部分进行了修改。当退款者为邀请人时，直接把相关订单的应到金额和已到金额都清零；当退款者为被邀请人时，其邀请者重新按照去除退款者之后的新人有效前三单计算佣金金额，并按照佣金提成比例分别对前三单的佣金进行更新


